### PR TITLE
fix: NOTION 환경변수 복원

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -20,9 +20,13 @@ jobs:
 
       - name: Generate Environment Variables File for Production
         run: |
+          echo "NOTION_SECRET_KEY=$NOTION_SECRET_KEY" >> .env.production
+          echo "NOTION_BOOK_DATABASE_ID=$NOTION_BOOK_DATABASE_ID" >> .env.production
           echo "NEXT_PUBLIC_HASHTAG_API_URL=$NEXT_PUBLIC_HASHTAG_API_URL" >> .env.production
           echo "NEXT_PUBLIC_GAMES_API_URL=$NEXT_PUBLIC_GAMES_API_URL" >> .env.production
         env:
+          NOTION_SECRET_KEY: ${{ secrets.NOTION_SECRET_KEY }}
+          NOTION_BOOK_DATABASE_ID: ${{ secrets.NOTION_BOOK_DATABASE_ID }}
           NEXT_PUBLIC_HASHTAG_API_URL: ${{ secrets.NEXT_PUBLIC_HASHTAG_API_URL }}
           NEXT_PUBLIC_GAMES_API_URL: ${{ secrets.NEXT_PUBLIC_GAMES_API_URL }}
 


### PR DESCRIPTION
## Summary
- `/old` 페이지 빌드 실패 수정
- `NOTION_SECRET_KEY`, `NOTION_BOOK_DATABASE_ID` 환경변수를 워크플로우에 복원

## 원인
- 이전 PR에서 미사용으로 판단하고 제거했으나, `/old/components/BookContainer.tsx`에서 Notion API 호출에 사용 중이었음