### PR TITLE
fix: 블로그 무한루프 수정 및 CI 개선

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -1,5 +1,8 @@
 name: main
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 on:
   push:
     branches:

--- a/content/blog/20240704-202407-tanstack-query-initialdata-list-detail.mdx
+++ b/content/blog/20240704-202407-tanstack-query-initialdata-list-detail.mdx
@@ -79,11 +79,11 @@ const { data: mission } = useQuery({
 
 **Before — initialData 없이:**
 
-<video src="/blog/videos/20240704-202407-tanstack-query-initialdata-list-detail.mov" autoPlay loop muted playsInline width="100%" />
+<video src="/blog/videos/20240704-202407-tanstack-query-initialdata-list-detail.mov" autoPlay loop muted playsInline width="100%"></video>
 
 **After — initialData 적용:**
 
-<video src="/blog/videos/20240704-202407-tanstack-query-initialdata-list-detail-01.mov" autoPlay loop muted playsInline width="100%" />
+<video src="/blog/videos/20240704-202407-tanstack-query-initialdata-list-detail-01.mov" autoPlay loop muted playsInline width="100%"></video>
 
 적용 후에는 클릭하는 순간 이름, 설명, 보상, 프로젝트 정보가 바로 나온다. 진행 방법(`contentHtml`)이나 예상 시간/비용 같은 상세 전용 데이터만 API 응답 후에 채워진다.
 


### PR DESCRIPTION
## Summary
- 블로그 다이얼로그 무한 open/close 루프 수정
- `/neo` 경로를 `/`로 통일
- CloudFront 캐시 자동 무효화 추가
- GitHub Actions Node.js 24 강제 적용 (deprecation 대응)

## Test plan
- [ ] `/?post=slug` 접속 시 블로그 정상 열림 확인
- [ ] 배포 후 CloudFront 캐시 무효화 동작 확인