### PR TITLE
📱 모바일 뷰 구현 (앱 런처 + 블로그 + Instagram + 게임)

### DIFF
--- a/app/neo/components/NeoDesktop.tsx
+++ b/app/neo/components/NeoDesktop.tsx
@@ -4,6 +4,8 @@ import { Suspense } from "react";
 import { WindowManagerProvider } from "./WindowManager";
 import Desktop from "./Desktop";
 import BlogWindowSync from "./BlogWindowSync";
+import MobileLayout from "./mobile/MobileLayout";
+import { useIsMobile } from "../hooks/useIsMobile";
 import type { BlogFrontmatter } from "@/lib/blog";
 
 export interface BlogPostData {
@@ -21,6 +23,16 @@ export default function NeoDesktop({
   initialPostSlug?: string;
   books?: { id: string; coverUrl: string; title: string }[];
 }) {
+  const isMobile = useIsMobile();
+
+  if (isMobile) {
+    return (
+      <Suspense>
+        <MobileLayout blogPosts={blogPosts} initialPostSlug={initialPostSlug} />
+      </Suspense>
+    );
+  }
+
   return (
     <WindowManagerProvider>
       <Suspense>

--- a/app/neo/components/games/GameDashboard.tsx
+++ b/app/neo/components/games/GameDashboard.tsx
@@ -42,7 +42,7 @@ export default function GameDashboard({ stats }: { stats: DashboardStats }) {
   ];
 
   return (
-    <div className="flex gap-4 p-5 border-b-3 border-neo-border">
+    <div className="grid grid-cols-3 gap-2 p-3 border-b-3 border-neo-border md:flex md:gap-4 md:p-5">
       {cards.map((card) => (
         <div
           key={card.label}
@@ -51,7 +51,7 @@ export default function GameDashboard({ stats }: { stats: DashboardStats }) {
           <p className={`font-neo-heading text-[11px] uppercase tracking-wider ${card.labelColor}`}>
             {card.label}
           </p>
-          <p className={`font-space-grotesk text-4xl font-bold ${card.textColor} leading-tight`}>
+          <p className={`font-space-grotesk text-2xl font-bold md:text-4xl ${card.textColor} leading-tight`}>
             {card.main}
           </p>
           {card.sub && (

--- a/app/neo/components/games/GameFilterBar.tsx
+++ b/app/neo/components/games/GameFilterBar.tsx
@@ -31,8 +31,8 @@ export default function GameFilterBar({
   };
 
   return (
-    <div className="flex items-center justify-between h-[52px] px-5 border-b-3 border-neo-border">
-      <div className="flex gap-2">
+    <div className="flex items-center justify-between h-[52px] px-3 border-b-3 border-neo-border md:px-5">
+      <div className="scrollbar-hide flex gap-2 overflow-x-auto">
         {["All", ...genres].map((genre) => {
           const isActive = genre === "All" ? selectedGenre === null : selectedGenre === genre;
           return (

--- a/app/neo/components/games/GamesContent.tsx
+++ b/app/neo/components/games/GamesContent.tsx
@@ -130,8 +130,8 @@ function GamesExplorer() {
         sortKey={sortKey}
         onSortChange={setSortKey}
       />
-      <div className="neo-scrollbar flex-1 overflow-y-auto p-5">
-        <div className="grid grid-cols-3 gap-4">
+      <div className="neo-scrollbar flex-1 overflow-y-auto p-3 md:p-5">
+        <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 md:grid-cols-3 md:gap-4">
           {filteredGames.map((game) => (
             <GameCard key={game.id} game={game} />
           ))}

--- a/app/neo/components/instagram/InstagramContent.tsx
+++ b/app/neo/components/instagram/InstagramContent.tsx
@@ -404,27 +404,132 @@ function InstagramExplorer() {
   } = useInstagramData();
 
   return (
-    <div className="font-neo text-neo-text bg-neo-bg flex h-full">
-      <Sidebar
-        viewMode={viewMode}
-        onChangeViewMode={setViewMode}
-        hashtags={hashtags}
-        influencers={influencers}
-        selectedHashtagId={selectedHashtagId}
-        onSelectHashtag={setSelectedHashtagId}
-        selectedInfluencerId={selectedInfluencerId}
-        onSelectInfluencer={setSelectedInfluencerId}
-      />
+    <div className="font-neo text-neo-text bg-neo-bg flex h-full flex-col md:flex-row">
+      <div className="hidden md:block">
+        <Sidebar
+          viewMode={viewMode}
+          onChangeViewMode={setViewMode}
+          hashtags={hashtags}
+          influencers={influencers}
+          selectedHashtagId={selectedHashtagId}
+          onSelectHashtag={setSelectedHashtagId}
+          selectedInfluencerId={selectedInfluencerId}
+          onSelectInfluencer={setSelectedInfluencerId}
+        />
+      </div>
 
-      <div className="flex min-w-0 flex-1 flex-col overflow-hidden p-2 pl-0">
-        <div className="border-neo-border bg-neo-surface shadow-neo-sm flex min-h-0 flex-1 flex-col overflow-hidden rounded-lg border-3">
-          <TopBar
-            viewMode={viewMode}
-            currentTitle={currentTitle}
-            postCount={posts.length}
-            collectionType={collectionType}
-            onChangeCollectionType={setCollectionType}
-          />
+      {/* Mobile: inline controls */}
+      <div className="border-neo-border flex flex-col gap-2 border-b-3 p-3 md:hidden">
+        <div className="flex gap-2">
+          <button
+            type="button"
+            className={`border-neo-border flex h-9 flex-1 items-center justify-center gap-1.5 rounded-lg border-2 text-[13px] ${
+              viewMode === "hashtag"
+                ? "bg-[#C4B5FD] font-bold"
+                : "bg-neo-surface font-medium text-gray-500"
+            }`}
+            onClick={() => setViewMode("hashtag")}
+          >
+            <span className="font-black">#</span>
+          </button>
+          <button
+            type="button"
+            className={`border-neo-border flex h-9 flex-1 items-center justify-center gap-1.5 rounded-lg border-2 text-[13px] ${
+              viewMode === "influencer"
+                ? "bg-[#C4B5FD] font-bold"
+                : "bg-neo-surface font-medium text-gray-500"
+            }`}
+            onClick={() => setViewMode("influencer")}
+          >
+            <UserIcon size={16} />
+          </button>
+        </div>
+
+        {viewMode === "hashtag" && (
+          <div className="flex items-center justify-between">
+            <span className="text-[12px] font-bold text-gray-500">
+              해시태그 결과
+            </span>
+            <div className="border-neo-border flex overflow-hidden rounded-lg border-2">
+              <button
+                type="button"
+                className={`flex h-7 items-center px-3 text-[11px] ${
+                  collectionType === "top"
+                    ? "bg-[#C4B5FD] font-bold"
+                    : "bg-neo-surface font-semibold text-gray-500"
+                }`}
+                onClick={() => setCollectionType("top")}
+              >
+                인기순
+              </button>
+              <button
+                type="button"
+                className={`border-neo-border flex h-7 items-center border-l-2 px-3 text-[11px] ${
+                  collectionType === "recent"
+                    ? "bg-[#C4B5FD] font-bold"
+                    : "bg-neo-surface font-semibold text-gray-500"
+                }`}
+                onClick={() => setCollectionType("recent")}
+              >
+                최신순
+              </button>
+            </div>
+          </div>
+        )}
+
+        {viewMode === "influencer" && influencers.length > 0 && (
+          <div className="flex flex-col gap-1">
+            <span className="text-[11px] font-bold tracking-wide text-gray-500 uppercase">
+              Influencer ({influencers.length})
+            </span>
+            <div className="scrollbar-hide flex gap-1 overflow-x-auto">
+              {influencers.map((inf) => (
+                <button
+                  key={inf.id}
+                  type="button"
+                  className={`flex shrink-0 items-center gap-1.5 rounded-lg border-2 px-2.5 py-1.5 text-[12px] ${
+                    selectedInfluencerId === inf.id
+                      ? "border-neo-border bg-[#C4B5FD] font-bold"
+                      : "border-transparent bg-gray-50 font-medium"
+                  }`}
+                  onClick={() => setSelectedInfluencerId(inf.id)}
+                >
+                  {inf.profile_picture_url ? (
+                    // eslint-disable-next-line @next/next/no-img-element
+                    <img
+                      src={inf.profile_picture_url}
+                      alt={inf.username}
+                      className="border-neo-border size-5 rounded-full border object-cover"
+                    />
+                  ) : (
+                    <span className="border-neo-border flex size-5 items-center justify-center rounded-full border bg-gray-200">
+                      <UserIcon size={12} />
+                    </span>
+                  )}
+                  <span>{inf.username}</span>
+                  {inf.post_count !== undefined && (
+                    <span className="border-neo-border rounded border bg-blue-200 px-1 py-px text-[9px] font-bold">
+                      {inf.post_count}
+                    </span>
+                  )}
+                </button>
+              ))}
+            </div>
+          </div>
+        )}
+      </div>
+
+      <div className="flex min-w-0 flex-1 flex-col overflow-hidden p-0 md:p-2 md:pl-0">
+        <div className="border-neo-border bg-neo-surface flex min-h-0 flex-1 flex-col overflow-hidden border-0 md:shadow-neo-sm md:rounded-lg md:border-3">
+          <div className="hidden md:block">
+            <TopBar
+              viewMode={viewMode}
+              currentTitle={currentTitle}
+              postCount={posts.length}
+              collectionType={collectionType}
+              onChangeCollectionType={setCollectionType}
+            />
+          </div>
           <PostGrid
             posts={posts}
             isLoading={activeQuery.isLoading}

--- a/app/neo/components/mobile/MobileAppScreen.tsx
+++ b/app/neo/components/mobile/MobileAppScreen.tsx
@@ -1,0 +1,40 @@
+"use client";
+
+import type { ReactNode } from "react";
+import { ArrowLeft } from "lucide-react";
+
+export default function MobileAppScreen({
+  title,
+  color,
+  onBack,
+  children,
+}: {
+  title: string;
+  color: string;
+  onBack: () => void;
+  children: ReactNode;
+}) {
+  return (
+    <div className="flex h-full flex-col">
+      {/* Title Bar */}
+      <div
+        className="border-neo-border flex h-12 shrink-0 items-center gap-3 border-b-3 px-3"
+        style={{ background: color }}
+      >
+        <button
+          type="button"
+          onClick={onBack}
+          className="neo-btn border-neo-border bg-neo-surface flex size-8 items-center justify-center rounded-lg border-3 shadow-[2px_2px_0px_0px_#1A1A2E]"
+        >
+          <ArrowLeft className="text-neo-text size-4" strokeWidth={3} />
+        </button>
+        <span className="font-neo-heading text-neo-text text-sm font-bold">
+          {title}
+        </span>
+      </div>
+
+      {/* Content */}
+      <div className="min-h-0 flex-1 overflow-hidden">{children}</div>
+    </div>
+  );
+}

--- a/app/neo/components/mobile/MobileBlogDetail.tsx
+++ b/app/neo/components/mobile/MobileBlogDetail.tsx
@@ -1,0 +1,106 @@
+"use client";
+
+import { useState } from "react";
+import type { BlogPostData } from "../NeoDesktop";
+
+const TAG_COLORS = [
+  "bg-neo-info text-white",
+  "bg-neo-primary text-white",
+  "bg-neo-success text-white",
+  "bg-neo-warning text-white",
+  "bg-[#a78bfa] text-white",
+] as const;
+
+function getTagColor(tag: string) {
+  let hash = 0;
+  for (let i = 0; i < tag.length; i++)
+    hash = tag.charCodeAt(i) + ((hash << 5) - hash);
+  return TAG_COLORS[Math.abs(hash) % TAG_COLORS.length];
+}
+
+function formatDate(dateStr: string) {
+  const day = new Date(dateStr);
+  return `${day.getFullYear()}.${String(day.getMonth() + 1).padStart(2, "0")}.${String(day.getDate()).padStart(2, "0")}`;
+}
+
+const CATEGORY_LABELS: Record<string, string> = {
+  dev: "개발",
+  retrospect: "회고",
+  daily: "일상",
+  anime: "애니",
+};
+
+const FONT_OPTIONS = [
+  { key: "pretendard", label: "고딕", className: "font-pretendard" },
+  { key: "noto-serif", label: "명조", className: "font-noto-serif" },
+  { key: "ibm-plex", label: "IBM", className: "font-ibm-plex" },
+] as const;
+
+type FontKey = (typeof FONT_OPTIONS)[number]["key"];
+
+export default function MobileBlogDetail({ post }: { post: BlogPostData }) {
+  const [fontKey, setFontKey] = useState<FontKey>("pretendard");
+  const fontClassName = FONT_OPTIONS.find((o) => o.key === fontKey)?.className;
+
+  return (
+    <div className="neo-scrollbar h-full overflow-y-auto">
+      {/* Header */}
+      <div className="border-neo-border border-b-3 px-5 py-5">
+        {/* Tags */}
+        <div className="mb-3 flex flex-wrap gap-1.5">
+          {post.frontmatter.tags.map((tag) => (
+            <span
+              key={tag}
+              className={`${getTagColor(tag)} border-neo-border rounded-md border-2 px-2 py-0.5 text-[11px] font-semibold`}
+            >
+              #{tag}
+            </span>
+          ))}
+        </div>
+
+        {/* Title */}
+        <h1 className="font-neo-heading text-neo-text text-xl leading-snug font-bold">
+          {post.frontmatter.title}
+        </h1>
+
+        {/* Meta */}
+        <div className="mt-2 flex items-center gap-3 text-[12px] text-gray-500">
+          <span>{formatDate(post.frontmatter.date)}</span>
+          <span className="text-neo-border">|</span>
+          <span>{CATEGORY_LABELS[post.frontmatter.category] ?? post.frontmatter.category}</span>
+        </div>
+      </div>
+
+      {/* Font Switcher */}
+      <div className="flex justify-end px-4 pt-3 pb-1">
+        <div className="flex items-center gap-2">
+          <span className="text-[11px] font-semibold text-gray-400">글꼴</span>
+          <div className="border-neo-border flex overflow-hidden rounded-lg border-2">
+            {FONT_OPTIONS.map((opt) => (
+              <button
+                key={opt.key}
+                type="button"
+                onClick={() => setFontKey(opt.key)}
+                className={`px-2.5 py-1 text-[11px] font-semibold transition-colors ${
+                  fontKey === opt.key
+                    ? "bg-neo-accent text-neo-text"
+                    : "bg-neo-surface hover:bg-neo-bg text-gray-500"
+                }`}
+              >
+                {opt.label}
+              </button>
+            ))}
+          </div>
+        </div>
+      </div>
+
+      {/* Content */}
+      <div className="px-5 pb-10 pt-2">
+        <div
+          className={`neo-blog-content ${fontClassName}`}
+          dangerouslySetInnerHTML={{ __html: post.html }}
+        />
+      </div>
+    </div>
+  );
+}

--- a/app/neo/components/mobile/MobileBlogList.tsx
+++ b/app/neo/components/mobile/MobileBlogList.tsx
@@ -1,0 +1,120 @@
+"use client";
+
+import { useState } from "react";
+import type { BlogPostData } from "../NeoDesktop";
+
+const CATEGORIES = [
+  { key: "all", label: "전체" },
+  { key: "dev", label: "개발" },
+  { key: "retrospect", label: "회고" },
+  { key: "daily", label: "일상" },
+  { key: "anime", label: "애니" },
+] as const;
+
+const TAG_COLORS = [
+  "bg-neo-info text-white",
+  "bg-neo-primary text-white",
+  "bg-neo-success text-white",
+  "bg-neo-warning text-white",
+  "bg-[#a78bfa] text-white",
+] as const;
+
+function getTagColor(tag: string) {
+  let hash = 0;
+  for (let i = 0; i < tag.length; i++)
+    hash = tag.charCodeAt(i) + ((hash << 5) - hash);
+  return TAG_COLORS[Math.abs(hash) % TAG_COLORS.length];
+}
+
+function formatDate(dateStr: string) {
+  const day = new Date(dateStr);
+  return `${day.getFullYear()}.${String(day.getMonth() + 1).padStart(2, "0")}.${String(day.getDate()).padStart(2, "0")}`;
+}
+
+export default function MobileBlogList({
+  posts,
+  onSelectPost,
+}: {
+  posts: BlogPostData[];
+  onSelectPost: (slug: string) => void;
+}) {
+  const [category, setCategory] = useState("all");
+
+  const filteredPosts =
+    category === "all"
+      ? posts
+      : posts.filter((p) => p.frontmatter.category === category);
+
+  return (
+    <div className="flex h-full flex-col">
+      {/* Category Tabs */}
+      <div className="border-neo-border flex shrink-0 gap-2 border-b-3 px-4 py-3">
+        {CATEGORIES.map((cat) => (
+          <button
+            key={cat.key}
+            type="button"
+            onClick={() => setCategory(cat.key)}
+            className={`font-neo-heading rounded-lg border-3 px-3 py-1.5 text-xs font-bold transition-colors ${
+              category === cat.key
+                ? "border-neo-border bg-neo-text text-white shadow-none"
+                : "border-neo-border bg-neo-surface text-neo-text shadow-[2px_2px_0px_0px_#1A1A2E]"
+            }`}
+          >
+            {cat.label}
+          </button>
+        ))}
+      </div>
+
+      {/* Post Cards */}
+      <div className="neo-scrollbar flex-1 overflow-y-auto px-4 py-3">
+        <div className="flex flex-col gap-3">
+          {filteredPosts.map((post) => (
+            <button
+              key={post.slug}
+              type="button"
+              onClick={() => onSelectPost(post.slug)}
+              className="border-neo-border bg-neo-surface shadow-neo-md rounded-xl border-3 p-4 text-left"
+            >
+              {/* Tags */}
+              <div className="mb-2 flex flex-wrap gap-1.5">
+                {post.frontmatter.tags.slice(0, 3).map((tag) => (
+                  <span
+                    key={tag}
+                    className={`${getTagColor(tag)} rounded-md border-2 border-neo-border px-2 py-0.5 text-[10px] font-semibold`}
+                  >
+                    {tag}
+                  </span>
+                ))}
+              </div>
+
+              {/* Title */}
+              <h3 className="font-neo-heading text-neo-text text-[15px] leading-snug font-bold">
+                {post.frontmatter.title}
+              </h3>
+
+              {/* Summary */}
+              {post.frontmatter.summary && (
+                <p className="mt-1.5 line-clamp-2 text-[12px] leading-relaxed text-gray-500">
+                  {post.frontmatter.summary}
+                </p>
+              )}
+
+              {/* Meta */}
+              <div className="mt-2 flex items-center gap-2 text-[11px] text-gray-400">
+                <span>{formatDate(post.frontmatter.date)}</span>
+                <span>·</span>
+                <span>{post.frontmatter.category}</span>
+              </div>
+            </button>
+          ))}
+
+          {filteredPosts.length === 0 && (
+            <p className="py-8 text-center text-sm text-gray-400">
+              글이 없습니다.
+            </p>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/neo/components/mobile/MobileHome.tsx
+++ b/app/neo/components/mobile/MobileHome.tsx
@@ -1,0 +1,61 @@
+"use client";
+
+import { DESKTOP_ITEMS } from "../WindowManager";
+import { Menu } from "lucide-react";
+
+const MOBILE_APPS = DESKTOP_ITEMS.map((item) => ({
+  id: item.id,
+  title: item.title.replace(".exe", ""),
+  icon: item.icon,
+  color: item.color,
+}));
+
+export default function MobileHome({
+  onOpenApp,
+}: {
+  onOpenApp: (appId: string) => void;
+}) {
+  return (
+    <div className="flex h-full flex-col">
+      {/* Header */}
+      <div className="flex items-center justify-between px-5 pt-3 pb-2">
+        <h1 className="font-neo-heading text-neo-text text-lg font-bold tracking-tight">
+          KYU-NIVERSE
+        </h1>
+        <button
+          type="button"
+          className="neo-btn border-neo-border bg-neo-surface flex size-10 items-center justify-center rounded-xl border-3 shadow-[3px_3px_0px_0px_#1A1A2E]"
+        >
+          <Menu className="text-neo-text size-5" strokeWidth={3} />
+        </button>
+      </div>
+
+      {/* App Grid */}
+      <div className="flex-1 px-6 pt-6">
+        <div className="grid grid-cols-4 gap-x-4 gap-y-6">
+          {MOBILE_APPS.map((app) => (
+            <button
+              key={app.id}
+              type="button"
+              className="flex flex-col items-center gap-2"
+              onClick={() => onOpenApp(app.id)}
+            >
+              <div
+                className="border-neo-border flex size-16 items-center justify-center rounded-2xl border-3"
+                style={{
+                  background: app.color,
+                  boxShadow: "3px 3px 0px 0px #1A1A2E",
+                }}
+              >
+                <span className="text-2xl">{app.icon}</span>
+              </div>
+              <span className="font-neo-heading text-neo-text text-[11px] font-bold">
+                {app.title}
+              </span>
+            </button>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/neo/components/mobile/MobileLayout.tsx
+++ b/app/neo/components/mobile/MobileLayout.tsx
@@ -1,0 +1,169 @@
+"use client";
+
+import { useState, useCallback, useEffect } from "react";
+import { useSearchParams, useRouter } from "next/navigation";
+import MobileHome from "./MobileHome";
+import MobileAppScreen from "./MobileAppScreen";
+import MobileBlogList from "./MobileBlogList";
+import MobileBlogDetail from "./MobileBlogDetail";
+import MobileNotification from "./MobileNotification";
+import InstagramContent from "../instagram/InstagramContent";
+import GamesContent from "../games/GamesContent";
+import {
+  ResumeContent,
+  PlaceholderContent,
+} from "../WindowContents";
+import type { BlogPostData } from "../NeoDesktop";
+
+type Screen =
+  | { type: "home" }
+  | { type: "app"; appId: string }
+  | { type: "blog-detail"; appId: "blog"; slug: string };
+
+const APP_TITLES: Record<string, string> = {
+  blog: "블로그.exe",
+  instagram: "Instagram.exe",
+  games: "게임.exe",
+  resume: "이력서.exe",
+  bookstore: "서점.exe",
+};
+
+const APP_COLORS: Record<string, string> = {
+  blog: "#FFE66D",
+  instagram: "#C4B5FD",
+  games: "#FF922B",
+  resume: "#FF6B6B",
+  bookstore: "#339AF0",
+};
+
+export default function MobileLayout({
+  blogPosts,
+  initialPostSlug,
+}: {
+  blogPosts: BlogPostData[];
+  initialPostSlug?: string;
+}) {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+
+  const [screen, setScreen] = useState<Screen>(() => {
+    const postSlug = initialPostSlug ?? searchParams.get("post");
+    if (postSlug && blogPosts.some((p) => p.slug === postSlug)) {
+      return { type: "blog-detail", appId: "blog", slug: postSlug };
+    }
+    return { type: "home" };
+  });
+
+  useEffect(() => {
+    const slug = searchParams.get("post");
+    if (slug && screen.type === "home" && blogPosts.some((p) => p.slug === slug)) {
+      setScreen({ type: "blog-detail", appId: "blog", slug });
+    }
+  }, [searchParams, blogPosts, screen.type]);
+
+  const goHome = useCallback(() => {
+    setScreen({ type: "home" });
+    router.push("/", { scroll: false });
+  }, [router]);
+
+  const openApp = useCallback((appId: string) => {
+    setScreen({ type: "app", appId });
+  }, []);
+
+  const openBlogDetail = useCallback(
+    (slug: string) => {
+      setScreen({ type: "blog-detail", appId: "blog", slug });
+      router.push(`/?post=${slug}`, { scroll: false });
+    },
+    [router],
+  );
+
+  const goBack = useCallback(() => {
+    if (screen.type === "blog-detail") {
+      setScreen({ type: "app", appId: "blog" });
+      router.push("/", { scroll: false });
+    } else {
+      goHome();
+    }
+  }, [screen, goHome, router]);
+
+  // 블로그 앱이 활성 상태인지 (리스트 or 상세)
+  const isBlogActive =
+    (screen.type === "app" && screen.appId === "blog") ||
+    screen.type === "blog-detail";
+
+  // 블로그 상세가 열려있는지
+  const blogDetailSlug =
+    screen.type === "blog-detail" ? screen.slug : null;
+  const blogDetailPost = blogDetailSlug
+    ? blogPosts.find((p) => p.slug === blogDetailSlug) ?? null
+    : null;
+
+  return (
+    <div
+      className="bg-neo-bg font-neo relative h-[100dvh] w-screen overflow-hidden"
+      style={{
+        backgroundImage: "radial-gradient(circle, #1A1A2E 1.2px, transparent 1.2px)",
+        backgroundSize: "20px 20px",
+      }}
+    >
+      {/* Home */}
+      {screen.type === "home" && (
+        <>
+          <MobileHome onOpenApp={openApp} />
+          <MobileNotification />
+        </>
+      )}
+
+      {/* Non-blog apps */}
+      {screen.type === "app" && screen.appId !== "blog" && (
+        <MobileAppScreen
+          title={APP_TITLES[screen.appId] ?? screen.appId}
+          color={APP_COLORS[screen.appId] ?? "#FFE66D"}
+          onBack={goBack}
+        >
+          {renderAppContent(screen.appId)}
+        </MobileAppScreen>
+      )}
+
+      {/* Blog: 리스트는 블로그가 열려있는 동안 항상 마운트 유지 */}
+      <div
+        className={`absolute inset-0 flex flex-col ${isBlogActive ? "" : "pointer-events-none invisible"}`}
+      >
+        <MobileAppScreen
+          title="블로그.exe"
+          color={APP_COLORS.blog}
+          onBack={goBack}
+        >
+          <MobileBlogList posts={blogPosts} onSelectPost={openBlogDetail} />
+        </MobileAppScreen>
+      </div>
+
+      {/* Blog detail: 리스트 위에 오버레이 */}
+      {blogDetailPost && (
+        <div className="absolute inset-0 z-10 flex flex-col">
+          <MobileAppScreen
+            title="블로그.exe"
+            color={APP_COLORS.blog}
+            onBack={goBack}
+          >
+            <MobileBlogDetail post={blogDetailPost} />
+          </MobileAppScreen>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function renderAppContent(appId: string) {
+  switch (appId) {
+    case "instagram":
+      return <InstagramContent />;
+    case "games":
+      return <GamesContent />;
+    case "resume":
+      return <ResumeContent />;
+    default:
+      return <PlaceholderContent title={appId} icon="📁" />;
+  }
+}

--- a/app/neo/components/mobile/MobileNotification.tsx
+++ b/app/neo/components/mobile/MobileNotification.tsx
@@ -1,0 +1,80 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { X } from "lucide-react";
+
+const NOTIFICATION_DELAY_MS = 1200;
+const CLOSE_ANIMATION_MS = 200;
+
+export default function MobileNotification() {
+  const [visible, setVisible] = useState(false);
+  const [closing, setClosing] = useState(false);
+
+  useEffect(() => {
+    const timer = setTimeout(() => setVisible(true), NOTIFICATION_DELAY_MS);
+    return () => clearTimeout(timer);
+  }, []);
+
+  const handleClose = () => {
+    setClosing(true);
+    setTimeout(() => setVisible(false), CLOSE_ANIMATION_MS);
+  };
+
+  if (!visible) return null;
+
+  return (
+    <div
+      className={`absolute right-4 bottom-6 left-4 z-50 ${
+        closing ? "neo-notification--closing" : "neo-notification--opening"
+      }`}
+    >
+      <div className="border-neo-border bg-neo-surface shadow-neo-md overflow-hidden rounded-xl border-3">
+        {/* Title */}
+        <div className="bg-neo-warning border-neo-border flex items-center justify-between border-b-3 px-3 py-2">
+          <div className="flex items-center gap-2">
+            <span className="text-sm">🔔</span>
+            <span className="font-neo-heading text-neo-text text-xs font-bold">
+              알림
+            </span>
+            <span className="relative flex size-2.5">
+              <span className="bg-neo-info absolute inline-flex h-full w-full animate-ping rounded-full opacity-75" />
+              <span className="bg-neo-info relative inline-flex size-2.5 rounded-full" />
+            </span>
+          </div>
+          <button
+            type="button"
+            onClick={handleClose}
+            className="neo-btn bg-neo-primary border-neo-border flex size-6 items-center justify-center rounded-md border-2 text-xs font-bold"
+          >
+            <X className="size-3.5" strokeWidth={3} />
+          </button>
+        </div>
+
+        {/* Body */}
+        <div className="p-4">
+          <p className="font-neo-heading text-neo-text text-base leading-snug font-bold">
+            Kyuniverse 페이지를
+            <br />
+            <span className="bg-neo-accent border-neo-border inline-block -rotate-1 rounded-md border-2 px-2 py-0.5">
+              renewal 했습니다!
+            </span>
+          </p>
+          <p className="text-neo-text mt-2 text-[13px] leading-relaxed font-semibold">
+            이번 컨셉은{" "}
+            <span className="bg-neo-primary inline-block rotate-1 rounded-md px-1.5 font-black text-white">
+              NEO BRUTALISM
+            </span>{" "}
+            입니다.
+          </p>
+          <button
+            type="button"
+            onClick={handleClose}
+            className="neo-btn bg-neo-secondary border-neo-border shadow-neo-sm mt-3 w-full rounded-lg border-2 py-2 text-sm font-extrabold tracking-wide"
+          >
+            OK, GOT IT
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/neo/hooks/useIsMobile.ts
+++ b/app/neo/hooks/useIsMobile.ts
@@ -1,0 +1,20 @@
+"use client";
+
+import { useState, useEffect } from "react";
+
+const MOBILE_BREAKPOINT = 768;
+
+export function useIsMobile() {
+  const [isMobile, setIsMobile] = useState(false);
+
+  useEffect(() => {
+    const mql = window.matchMedia(`(max-width: ${MOBILE_BREAKPOINT - 1}px)`);
+    setIsMobile(mql.matches);
+
+    const handleChange = (e: MediaQueryListEvent) => setIsMobile(e.matches);
+    mql.addEventListener("change", handleChange);
+    return () => mql.removeEventListener("change", handleChange);
+  }, []);
+
+  return isMobile;
+}


### PR DESCRIPTION
- useIsMobile 훅으로 뷰포트 기반 모바일/데스크톱 분기 (768px)
- MobileLayout: 스택 네비게이션 + 블로그 스크롤 위치 유지
- MobileHome: 앱 런처 홈 (4열 아이콘 그리드 + 도트 배경)
- MobileBlogList/Detail: 카테고리 탭 + 카드 리스트 + MDX 본문
- InstagramContent: 사이드바 → 인라인 탭/필터 반응형
- Games: 통계 카드 3열 + 게임 카드 1열 반응형