### PR TITLE
🐛 모바일 뷰 버그 수정 + UI 개선

### DIFF
--- a/app/neo.css
+++ b/app/neo.css
@@ -98,7 +98,7 @@
 .neo-scrollbar::-webkit-scrollbar { width: 8px; }
 .neo-scrollbar::-webkit-scrollbar-track { background: var(--color-neo-bg); }
 .neo-scrollbar::-webkit-scrollbar-thumb {
-  background: var(--color-neo-border);
+  background: #C4B5FD;
   border: 2px solid var(--color-neo-bg);
   border-radius: 12px;
 }

--- a/app/neo/components/instagram/InstagramContent.tsx
+++ b/app/neo/components/instagram/InstagramContent.tsx
@@ -446,33 +446,54 @@ function InstagramExplorer() {
         </div>
 
         {viewMode === "hashtag" && (
-          <div className="flex items-center justify-between">
-            <span className="text-[12px] font-bold text-gray-500">
-              해시태그 결과
-            </span>
-            <div className="border-neo-border flex overflow-hidden rounded-lg border-2">
-              <button
-                type="button"
-                className={`flex h-7 items-center px-3 text-[11px] ${
-                  collectionType === "top"
-                    ? "bg-[#C4B5FD] font-bold"
-                    : "bg-neo-surface font-semibold text-gray-500"
-                }`}
-                onClick={() => setCollectionType("top")}
-              >
-                인기순
-              </button>
-              <button
-                type="button"
-                className={`border-neo-border flex h-7 items-center border-l-2 px-3 text-[11px] ${
-                  collectionType === "recent"
-                    ? "bg-[#C4B5FD] font-bold"
-                    : "bg-neo-surface font-semibold text-gray-500"
-                }`}
-                onClick={() => setCollectionType("recent")}
-              >
-                최신순
-              </button>
+          <div className="flex flex-col gap-2">
+            {hashtags.length > 0 && (
+              <div className="scrollbar-hide flex gap-1 overflow-x-auto">
+                {hashtags.map((h) => (
+                  <button
+                    key={h.id}
+                    type="button"
+                    className={`flex shrink-0 items-center gap-1 rounded-lg border-2 px-2.5 py-1.5 text-[12px] ${
+                      selectedHashtagId === h.id
+                        ? "border-neo-border bg-[#C4B5FD] font-bold"
+                        : "border-transparent bg-gray-50 font-medium"
+                    }`}
+                    onClick={() => setSelectedHashtagId(h.id)}
+                  >
+                    <span className="font-black text-[#8B5CF6]">#</span>
+                    <span>{h.name}</span>
+                  </button>
+                ))}
+              </div>
+            )}
+            <div className="flex items-center justify-between">
+              <span className="text-[12px] font-bold text-gray-500">
+                해시태그 결과
+              </span>
+              <div className="border-neo-border flex overflow-hidden rounded-lg border-2">
+                <button
+                  type="button"
+                  className={`flex h-7 items-center px-3 text-[11px] ${
+                    collectionType === "top"
+                      ? "bg-[#C4B5FD] font-bold"
+                      : "bg-neo-surface font-semibold text-gray-500"
+                  }`}
+                  onClick={() => setCollectionType("top")}
+                >
+                  인기순
+                </button>
+                <button
+                  type="button"
+                  className={`border-neo-border flex h-7 items-center border-l-2 px-3 text-[11px] ${
+                    collectionType === "recent"
+                      ? "bg-[#C4B5FD] font-bold"
+                      : "bg-neo-surface font-semibold text-gray-500"
+                  }`}
+                  onClick={() => setCollectionType("recent")}
+                >
+                  최신순
+                </button>
+              </div>
             </div>
           </div>
         )}

--- a/app/neo/components/mobile/MobileLayout.tsx
+++ b/app/neo/components/mobile/MobileLayout.tsx
@@ -139,9 +139,9 @@ export default function MobileLayout({
         </MobileAppScreen>
       </div>
 
-      {/* Blog detail: 리스트 위에 오버레이 */}
+      {/* Blog detail: 리스트 위에 오버레이 (불투명 배경) */}
       {blogDetailPost && (
-        <div className="absolute inset-0 z-10 flex flex-col">
+        <div className="absolute inset-0 z-10 flex flex-col bg-white">
           <MobileAppScreen
             title="블로그.exe"
             color={APP_COLORS.blog}


### PR DESCRIPTION
- 블로그 상세 오버레이 배경을 불투명 흰색으로 변경 (뒤 콘텐츠 비침 수정)
- Instagram 모바일 해시태그 선택 칩 리스트 추가
- 스크롤바 색상 보라색(#C4B5FD)으로 변경